### PR TITLE
Feature/detect ext power

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "signalk-geekworm-x728",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {
@@ -10,6 +10,15 @@
             "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
             "requires": {
                 "file-uri-to-path": "1.0.0"
+            }
+        },
+        "epoll": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/epoll/-/epoll-4.0.1.tgz",
+            "integrity": "sha512-BgCq0nEsk+XI7y9qjrRtt9uXsyFEdvevvq42xl6t/hKZjxLSDZreD9rTZ0pU40V//c3Zzk2PZGuIsn8YJHSJ4g==",
+            "requires": {
+                "bindings": "^1.5.0",
+                "nan": "^2.14.2"
             }
         },
         "file-uri-to-path": {
@@ -26,10 +35,24 @@
                 "nan": "^2.14.2"
             }
         },
+        "lodash.debounce": {
+            "version": "4.0.8",
+            "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
+            "integrity": "sha1-gteb/zCmfEAF/9XiUVMArZyk168="
+        },
         "nan": {
             "version": "2.15.0",
             "resolved": "https://registry.npmjs.org/nan/-/nan-2.15.0.tgz",
             "integrity": "sha512-8ZtvEnA2c5aYCZYd1cvgdnU6cqwixRoYg70xPLWUws5ORTa/lnw+u4amixRS/Ac5U5mQVgp9pnlSUnbNWFaWZQ=="
+        },
+        "onoff": {
+            "version": "6.0.3",
+            "resolved": "https://registry.npmjs.org/onoff/-/onoff-6.0.3.tgz",
+            "integrity": "sha512-xtVlwRDzswYM69bzzIui/qzu7QHsFnjsQiCV1iYVA/HXt5xdc9utc97SYAlXzK8wAhIN7+H7MaVqh2vpfdKk9A==",
+            "requires": {
+                "epoll": "^4.0.1",
+                "lodash.debounce": "^4.0.8"
+            }
         }
     }
 }

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
         "signalk-category-hardware"
     ],
     "dependencies": {
-        "i2c-bus": "^5.2.2"
+        "i2c-bus": "^5.2.2",
+        "onoff": "^6.0.3"
     }
 }


### PR DESCRIPTION
Addresses #1 

Detect if the Rpi has external power supplied, or if Rpi has loss of external power and is running on battery.  Push message to notification tree of SignalK indicating appropriately.  The notification is currently pushed to hard-coded path `notifications.electrical.batteries.rpi` as an `alert` with both `visual` and `sound` methods.  Consider making these settings configurable.